### PR TITLE
Added lifecycle rules config option

### DIFF
--- a/s3.cfndsl.rb
+++ b/s3.cfndsl.rb
@@ -20,8 +20,6 @@ CloudFormation do
     end
 
 
-
-
     if bucket_type == 'create_if_not_exists'
       Resource("#{safe_bucket_name}") do
         Type 'Custom::S3BucketCreateOnly'
@@ -38,6 +36,7 @@ CloudFormation do
           { Key: 'EnvironmentType', Value: Ref("EnvironmentType") }
         ])
         NotificationConfiguration notification_configurations unless notification_configurations.empty?
+        LifecycleConfiguration({ Rules: config['lifecycle_rules'] }) if config.has_key?('lifecycle_rules')
       end
     end
 

--- a/tests/lifecycle_rules.test.yaml
+++ b/tests/lifecycle_rules.test.yaml
@@ -1,0 +1,31 @@
+test_metadata:
+  type: config
+  name: bucket with lifecycle rules
+  description: Create bucket and enable lambda notifcation on creation of new objects
+
+
+buckets:
+  normal-bucket:
+    type: default  
+    lifecycle_rules:
+      - 
+        Id: myCustomRule
+        ExpirationInDays: 2555
+        Prefix: logs/
+        Status: Enabled
+        Transitions:
+          - 
+            StorageClass: STANDARD_IA
+            TransitionInDays: 7
+          - 
+            StorageClass: GLACIER
+            TransitionInDays: 30     
+      - 
+        Id: myOtherRule
+        ExpirationInDays: 2555
+        Prefix: documents/
+        Status: Enabled
+        Transitions:
+          - 
+            StorageClass: STANDARD_IA
+            TransitionInDays: 7    


### PR DESCRIPTION
Added lifecycle rule configuration.
Rules config uses the same yaml objects as raw cloudformation.
More on configuration can be found here: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-lifecycleconfig-rule.html
