### PR TITLE
Added bucket policy option

### DIFF
--- a/tests/bucket_policy.test.yaml
+++ b/tests/bucket_policy.test.yaml
@@ -1,0 +1,17 @@
+test_metadata:
+  type: config
+  name: Bucket and policy
+  description: Create bucket and bucket policy
+
+
+buckets:
+  normal-bucket:
+    type: default  
+    bucket-policy:
+      loadbalancer-logs:
+        actions:
+          - s3:PutObject
+        principal:
+          AWS: "arn:aws:iam::111111111111:root"
+        
+      


### PR DESCRIPTION
Add ability to define a bucket policy when creating buckets.
Defaults will allow full s3 access to the bucket for the root of the account that the bucket is in.