### PR TITLE
Cast MaxAgeSeconds as int in custom resource

### DIFF
--- a/.github/workflows/rspec.yaml
+++ b/.github/workflows/rspec.yaml
@@ -3,23 +3,6 @@ name: cftest
 on: [push, pull_request]
 
 jobs:
-  test:
-    name: test
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: set up ruby 2.7
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7.x
-    - name: install gems
-      run: gem install cfhighlander rspec 
-    - name: set cfndsl spec
-      run: cfndsl -u
-    - name: cftest
-      run: rspec
-      env:
-        AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_REGION: ap-southeast-2
+  rspec:
+    uses: theonestack/shared-workflows/.github/workflows/rspec.yaml@main
+    secrets: inherit

--- a/lambdas/s3_bucket.py
+++ b/lambdas/s3_bucket.py
@@ -58,8 +58,6 @@ def create_bucket(params, event, context):
   notifications = params['Notifications'] if 'Notifications' in params else None
   bucket_name = params['BucketName']
   cors_configuration = params['CorsConfiguration'] if 'CorsConfiguration' in params else None
-  if cors_configuration.get('MaxAgeSeconds')is not None:
-    cors_configuration['MaxAgeSeconds'] = int(cors_configuration['MaxAgeSeconds'])
   bucket_already_exists = True
 
   try:
@@ -165,6 +163,9 @@ def delete_notification(Bucket):
 def add_cors(cors_configuration, bucket_name):
   bucket_cors = s3r.BucketCors(bucket_name)
   cors_rules = []
+  if cors_configuration.get('MaxAgeSeconds')is not None:
+    cors_configuration['MaxAgeSeconds'] = int(cors_configuration['MaxAgeSeconds'])
+  print(f"Cors Configuration: {cors_configuration}")
 
   bucket_cors.put(
     CORSConfiguration={
@@ -172,7 +173,6 @@ def add_cors(cors_configuration, bucket_name):
     }
   )
   print(f"Put cors configuration request completed... for {bucket_name} :)")  
-
 
 def delete_cors(bucket_name):
   bucket_cors = s3r.BucketCors(bucket_name)

--- a/lambdas/s3_bucket.py
+++ b/lambdas/s3_bucket.py
@@ -163,8 +163,18 @@ def delete_notification(Bucket):
 def add_cors(cors_configuration, bucket_name):
   bucket_cors = s3r.BucketCors(bucket_name)
   cors_rules = []
-  if cors_configuration.get('MaxAgeSeconds')is not None:
-    cors_configuration['MaxAgeSeconds'] = int(cors_configuration['MaxAgeSeconds'])
+  
+  # Update MaxAgeSeconds to int if provided
+  if 'CorsRules' in cors_configuration and len(cors_configuration['CorsRules']) > 0:
+    for cors_rule in cors_configuration['CorsRules']:
+      if 'MaxAgeSeconds' in cors_rule:
+          try:
+              cors_rule['MaxAgeSeconds'] = int(cors_rule['MaxAgeSeconds'])
+          except ValueError:
+              print("Unable to convert MaxAgeSeconds to an integer.")
+  else:
+    print("CorsRules key not found.")
+  
   print(f"Cors Configuration: {cors_configuration}")
 
   bucket_cors.put(

--- a/lambdas/s3_bucket.py
+++ b/lambdas/s3_bucket.py
@@ -58,6 +58,8 @@ def create_bucket(params, event, context):
   notifications = params['Notifications'] if 'Notifications' in params else None
   bucket_name = params['BucketName']
   cors_configuration = params['CorsConfiguration'] if 'CorsConfiguration' in params else None
+  if cors_configuration.get('MaxAgeSeconds')is not None:
+    cors_configuration['MaxAgeSeconds'] = int(cors_configuration['MaxAgeSeconds'])
   bucket_already_exists = True
 
   try:


### PR DESCRIPTION
Fixed a bug where the max age would be set as a `string` instead of an `int` when deployed as a custom resource which occurs when the bucket type is set as `create_if_not_exists`

Also updated the github workflow to the standard shared workflow.

## Issue Example
- Failed deployment event
<img width="952" alt="Screen Shot 2023-05-24 at 12 41 30 pm" src="https://github.com/theonestack/hl-component-s3/assets/64295670/f5348e7f-8c46-40f5-bd50-41240b8de7dd">

- Cloudwatch Logs (Observe the MaxAgeSeconds is a string)
<img width="1203" alt="Screen Shot 2023-05-24 at 12 43 03 pm" src="https://github.com/theonestack/hl-component-s3/assets/64295670/0dca5864-e47c-4813-af1c-ad1a16ea026a">

## Post Fix Example
- Successful deployment
<img width="270" alt="Screen Shot 2023-05-24 at 12 43 29 pm" src="https://github.com/theonestack/hl-component-s3/assets/64295670/da6cc641-e85f-46ef-bd5f-b349597f5a53">

- Cloudwatch Logs (MaxAgeSeconds now is an int as expected)
<img width="1201" alt="Screen Shot 2023-05-24 at 12 44 08 pm" src="https://github.com/theonestack/hl-component-s3/assets/64295670/4568b6aa-6773-4f97-84c7-93541c290c15">


