### PR TITLE
feat: optionally enable bucket ACL for cloudfront logging bucket

### DIFF
--- a/s3.cfndsl.rb
+++ b/s3.cfndsl.rb
@@ -52,6 +52,14 @@ CloudFormation do
       cors_configuration['CorsRules'] = cors_rules
     end
 
+    # ACL
+    ownership_controls_rules = []
+    acl_rules = config.has_key?('acl_rules') ? config['acl_rules'] : []
+    acl_rules.each do |acl_rule|
+      ownership_control_rule = {}
+      ownership_control_rule['ObjectOwnership'] = acl_rule
+      ownership_controls_rules.append(ownership_control_rule)
+    end
 
     if bucket_type == 'create_if_not_exists'
       Resource("#{safe_bucket_name}") do
@@ -87,6 +95,9 @@ CloudFormation do
           DestinationBucketName: Ref("#{safe_bucket_name}AccessLogsBucket"),
           LogFilePrefix: FnIf("#{safe_bucket_name}SetLogFilePrefix", Ref("#{safe_bucket_name}LogFilePrefix"), Ref('AWS::NoValue'))
         }) if config.has_key?('enable_logging') && config['enable_logging']
+        OwnershipControls ({
+          Rules: ownership_controls_rules
+        }) if !ownership_controls_rules.empty?
       end
     end
 

--- a/spec/acl_spec.rb
+++ b/spec/acl_spec.rb
@@ -1,0 +1,39 @@
+require 'yaml'
+
+describe 'compiled component s3' do
+  
+  context 'cftest' do
+    it 'compiles test' do
+      expect(system("cfhighlander cftest #{@validate} --tests tests/acl.test.yaml")).to be_truthy
+    end      
+  end
+  
+  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/acl/s3.compiled.yaml") }
+  
+  context "Resource" do
+
+    
+    context "Normalbucket" do
+      let(:resource) { template["Resources"]["Normalbucket"] }
+
+      it "is of type AWS::S3::Bucket" do
+          expect(resource["Type"]).to eq("AWS::S3::Bucket")
+      end
+      
+      it "to have property BucketName" do
+          expect(resource["Properties"]["BucketName"]).to eq({"Fn::Sub"=>"normal-bucket"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-normal-bucket"}}, {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
+      it "to have property OwnershipControls" do
+          expect(resource["Properties"]["OwnershipControls"]).to eq({"Rules"=>[{"ObjectOwnership"=>"ObjectWriter"}]})
+      end
+      
+    end
+    
+  end
+
+end

--- a/tests/acl.test.yaml
+++ b/tests/acl.test.yaml
@@ -1,0 +1,11 @@
+test_metadata:
+  type: config
+  name: acl
+  description: set the description for your test
+
+# Insert your tests here
+buckets:
+  normal-bucket:
+    type: default
+    acl_rules:
+    -  ObjectWriter


### PR DESCRIPTION
Need to add the ability to enable ACL for a bucket in cloudfront

**Test results:**
`config`
```
buckets:
  Logs:
    bucket_name: "logs.${DnsDomain}"
    acl_rules:
    - BucketOwnerPreferred
```

