### PR TITLE
feat: s3 website

### DIFF
--- a/spec/website_redirect_to_another_bucket_spec.rb
+++ b/spec/website_redirect_to_another_bucket_spec.rb
@@ -1,0 +1,39 @@
+require 'yaml'
+
+describe 'compiled component s3' do
+  
+  context 'cftest' do
+    it 'compiles test' do
+      expect(system("cfhighlander cftest #{@validate} --tests tests/website_redirect_to_another_bucket.test.yaml")).to be_truthy
+    end      
+  end
+  
+  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/website_redirect_to_another_bucket/s3.compiled.yaml") }
+  
+  context "Resource" do
+
+    
+    context "Normalbucket" do
+      let(:resource) { template["Resources"]["Normalbucket"] }
+
+      it "is of type AWS::S3::Bucket" do
+          expect(resource["Type"]).to eq("AWS::S3::Bucket")
+      end
+      
+      it "to have property BucketName" do
+          expect(resource["Properties"]["BucketName"]).to eq({"Fn::Sub"=>"normal-bucket"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-normal-bucket"}}, {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
+      it "to have property WebsiteConfiguration" do
+          expect(resource["Properties"]["WebsiteConfiguration"]).to eq({"RedirectAllRequestsTo"=>{"HostName"=>"testbucket", "Protocol"=>"http"}})
+      end
+      
+    end
+    
+  end
+
+end

--- a/spec/website_spec.rb
+++ b/spec/website_spec.rb
@@ -1,0 +1,39 @@
+require 'yaml'
+
+describe 'compiled component s3' do
+  
+  context 'cftest' do
+    it 'compiles test' do
+      expect(system("cfhighlander cftest #{@validate} --tests tests/website.test.yaml")).to be_truthy
+    end      
+  end
+  
+  let(:template) { YAML.load_file("#{File.dirname(__FILE__)}/../out/tests/website/s3.compiled.yaml") }
+  
+  context "Resource" do
+
+    
+    context "Normalbucket" do
+      let(:resource) { template["Resources"]["Normalbucket"] }
+
+      it "is of type AWS::S3::Bucket" do
+          expect(resource["Type"]).to eq("AWS::S3::Bucket")
+      end
+      
+      it "to have property BucketName" do
+          expect(resource["Properties"]["BucketName"]).to eq({"Fn::Sub"=>"normal-bucket"})
+      end
+      
+      it "to have property Tags" do
+          expect(resource["Properties"]["Tags"]).to eq([{"Key"=>"Name", "Value"=>{"Fn::Sub"=>"${EnvironmentName}-normal-bucket"}}, {"Key"=>"Environment", "Value"=>{"Ref"=>"EnvironmentName"}}, {"Key"=>"EnvironmentType", "Value"=>{"Ref"=>"EnvironmentType"}}])
+      end
+      
+      it "to have property WebsiteConfiguration" do
+          expect(resource["Properties"]["WebsiteConfiguration"]).to eq({"ErrorDocument"=>"error.html", "IndexDocument"=>"index.html", "RoutingRules"=>[{"RedirectRule"=>{"HostName"=>"test1", "HttpRedirectCode"=>"301", "Protocol"=>"http", "ReplaceKeyWith"=>"test1"}, "RoutingRuleCondition"=>{"HttpErrorCodeReturnedEquals"=>"400", "KeyPrefixEquals"=>"test1"}}, {"RedirectRule"=>{"ReplaceKeyPrefixWith"=>"documents/"}, "RoutingRuleCondition"=>{"KeyPrefixEquals"=>"docs/"}}]})
+      end
+      
+    end
+    
+  end
+
+end

--- a/tests/website.test.yaml
+++ b/tests/website.test.yaml
@@ -1,0 +1,26 @@
+test_metadata:
+  type: config
+  name: website
+  description: s3 website with multiple routing rules
+
+# Insert your tests here
+buckets:
+  normal-bucket:
+    type: default
+    website:
+      redirect_requests: false
+      error_document: error.html
+      index_document: index.html
+      routing_rules: 
+      - redirect_rule:
+          hostname: "test1"
+          http_redirect_code: "301"
+          protocol: "http"
+          replace_key_with: "test1"
+        routing_rule_condition:
+          http_error_code_returned_equals: "400"
+          key_prefix_equals: "test1"
+      - redirect_rule:
+          replace_key_prefix_with: "documents/"
+        routing_rule_condition:
+          key_prefix_equals: "docs/"

--- a/tests/website_redirect_to_another_bucket.test.yaml
+++ b/tests/website_redirect_to_another_bucket.test.yaml
@@ -1,0 +1,13 @@
+test_metadata:
+  type: config
+  name: website_redirect_to_another_bucket
+  description: s3 website that redirects to another s3 bucket
+
+# Insert your tests here
+buckets:
+  normal-bucket:
+    type: default
+    website:
+      redirect_requests: true
+      redirect_hostname: "testbucket"
+      redirect_protocol: "http"


### PR DESCRIPTION
Add the ability to enable static website hosting for s3 (either to redirect to another bucket or host static website)

# Redirect to another bucket
```
buckets:
  normal-bucket:
    type: default
    website:
      redirect_requests: true
      redirect_hostname: "testbucket"
      redirect_protocol: "http"
```
![Screenshot 2023-12-08 at 4 12 28 pm](https://github.com/theonestack/hl-component-s3/assets/26110206/61825b18-800d-452a-b558-b3e0b7fb0539)

# Static website hosting
```
buckets:
  normal-bucket:
    type: default
    website:
      redirect_requests: false
      error_document: error.html
      index_document: index.html
```
![Screenshot 2023-12-08 at 4 13 07 pm](https://github.com/theonestack/hl-component-s3/assets/26110206/36f33c6d-aaf0-417e-8446-76cf21a2164f)

# Static website hosting with multiple redirection rules
```
buckets:
  normal-bucket:
    type: default
    website:
      redirect_requests: false
      error_document: error.html
      index_document: index.html
      routing_rules: 
      - redirect_rule:
          hostname: "test1"
          http_redirect_code: "301"
          protocol: "http"
          replace_key_with: "test1"
        routing_rule_condition:
          http_error_code_returned_equals: "400"
          key_prefix_equals: "test1"
      - redirect_rule:
          replace_key_prefix_with: "documents/"
        routing_rule_condition:
          key_prefix_equals: "docs/"
```
![Screenshot 2023-12-08 at 4 13 29 pm](https://github.com/theonestack/hl-component-s3/assets/26110206/f80679d8-c845-4f43-a06d-33aab3516562)
