### PR TITLE
Feature/s3 alias multiple region

### DIFF
--- a/s3.cfndsl.rb
+++ b/s3.cfndsl.rb
@@ -78,22 +78,14 @@ CloudFormation do
           dns_format = website['alias']['dns_format']
           subdomain = website['alias']['subdomain']
           fqdn = subdomain + "." + dns_format + "."
-          region = website['alias']['region']
           
-          # Reference: https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints
-          s3RegionMapping = {
-            "ap-southeast-2" => {
-              "hosted_zone_id" => "Z1WCIGYICN2BYD"
-            }
-          }
-
           Route53_RecordSet("#{safe_bucket_name}S3AliasRecord") do
             HostedZoneName FnSub("#{dns_format}.") 
             Name FnSub(fqdn)
             Type 'A'
             AliasTarget ({
-                DNSName: "s3-website-#{region}.amazonaws.com.",
-                HostedZoneId: s3RegionMapping[region]['hosted_zone_id']
+                DNSName: FnSub("s3-website-${AWS::Region}.amazonaws.com."),
+                HostedZoneId: FnFindInMap('S3AliasHostedZone', Ref('AWS::Region'), 'HostedZoneId')
             })
           end
         end

--- a/s3.mappings.yaml
+++ b/s3.mappings.yaml
@@ -1,0 +1,6 @@
+# Reference: https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_website_region_endpoints
+S3AliasHostedZone:
+  ap-southeast-2:
+    HostedZoneId: Z1WCIGYICN2BYD
+  us-west-2:
+    HostedZoneId: Z3BJ6K6RIION7M

--- a/spec/website_alias_spec.rb
+++ b/spec/website_alias_spec.rb
@@ -33,7 +33,7 @@ describe 'compiled component s3' do
       end
       
       it "to have property AliasTarget" do
-          expect(resource["Properties"]["AliasTarget"]).to eq({"DNSName"=>"s3-website-ap-southeast-2.amazonaws.com.", "HostedZoneId"=>"Z1WCIGYICN2BYD"})
+          expect(resource["Properties"]["AliasTarget"]).to eq({"DNSName"=>{"Fn::Sub"=>"s3-website-${AWS::Region}.amazonaws.com."}, "HostedZoneId"=>{"Fn::FindInMap"=>["S3AliasHostedZone", {"Ref"=>"AWS::Region"}, "HostedZoneId"]}})
       end
       
     end

--- a/tests/website_alias.test.yaml
+++ b/tests/website_alias.test.yaml
@@ -14,7 +14,6 @@ buckets:
       alias:
         dns_format: example.com
         subdomain: mybucket
-        region: ap-southeast-2
       routing_rules: 
       - redirect_rule:
           hostname: "test1"


### PR DESCRIPTION
fix issue with s3 alias when deploying to us-west-2 instead of ap-southeast-2
